### PR TITLE
update: 描画速度の向上/M5StackCore2対応/CardKB挿抜対応

### DIFF
--- a/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
+++ b/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
@@ -502,13 +502,7 @@ uint8 _getch(void) {
 //	while (!Serial.available());
 //  return(Serial.read());
   bool needCursorUpdate = false;
-  Wire.requestFrom(CARDKB_ADDR, 1);
-  while (!Wire.available()) {
-    // カーソル表示処理
-    if (canShowCursor || needCursorUpdate)
-       dispCursor(needCursorUpdate);
-  }
-  uint8 ch = Wire.read();
+  uint8 ch = Wire.requestFrom(CARDKB_ADDR, 1) ? Wire.read() : 0;
   switch (ch) {
     case 0x07:
 //    tone(SPK_PIN, 4000, 583);

--- a/M5Stack_RunCPM_vt100_CardKB/console.h
+++ b/M5Stack_RunCPM_vt100_CardKB/console.h
@@ -1,6 +1,8 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
+#include "lgfx.h"
+
 /* see main.c for definition */
 
 uint8 mask8bit = 0x7f;		// TO be used for masking 8 bit characters (XMODEM related)
@@ -27,8 +29,10 @@ void _putcon(uint8 ch)		// Puts a character
 
 void _puts(const char* str)	// Puts a \0 terminated string
 {
+	tft.startWrite();
 	while (*str)
 		_putcon(*(str++));
+	tft.endWrite();
 }
 
 void _puthex8(uint8 c)		// Puts a HH hex string

--- a/M5Stack_RunCPM_vt100_CardKB/lgfx.h
+++ b/M5Stack_RunCPM_vt100_CardKB/lgfx.h
@@ -1,0 +1,12 @@
+#ifndef __INCLUDE_LGFX_H__
+#define __INCLUDE_LGFX_H__
+
+#define LGFX_M5STACK               // M5Stack (Basic / Gray / Go / Fire)
+#define LGFX_M5STACK_CORE2         // M5Stack Core2
+#include <LovyanGFX.hpp>
+
+LGFX tft;                 // LGFXのインスタンスを作成。
+
+#endif
+
+extern LGFX tft;          // 複数のソースファイルから利用できるようにしておく


### PR DESCRIPTION
以下の変更を行いました。

・描画処理の前後にstartWrite() / endWrite() を配置することで描画時間を短縮しました。
・M5Stack Core2に対応しました。
・動作中にCardKBを挿し直ししても入力が行えるようにしました。