### PR TITLE
update: _kbhit関数と_getch関数を調整

### DIFF
--- a/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
+++ b/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
@@ -504,26 +504,30 @@ int _kbhit(void) {
 uint8 _getch(void) {
 //	while (!Serial.available());
 //  return(Serial.read());
-  bool needCursorUpdate = false;
-  if (!kbhit_char) _kbhit();
-  uint8 ch = kbhit_char;
-  kbhit_char = 0;
-  switch (ch) {
-    case 0x07:
-//    tone(SPK_PIN, 4000, 583);
-      break;
-    case 0xa8:    //Fn-C
-      ch = 0x03;  //Ctrl-C
-      break;
-    case 0x9f:    //Fn-H
-      ch = 0x08;  //Ctrl-H
-      break;
-    default:
-      break;
-  }
-  needCursorUpdate = ch;
-  if (canShowCursor || needCursorUpdate)
-     dispCursor(needCursorUpdate);
+  uint8 ch = 0;
+  do
+  {
+    if (_kbhit())
+    {
+      ch = kbhit_char;
+      kbhit_char = 0;
+      switch (ch) {
+        case 0x07:
+    //    tone(SPK_PIN, 4000, 583);
+          break;
+        case 0xa8:    //Fn-C
+          ch = 0x03;  //Ctrl-C
+          break;
+        case 0x9f:    //Fn-H
+          ch = 0x08;  //Ctrl-H
+          break;
+        default:
+          break;
+      }
+    }
+    if (canShowCursor || ch)
+       dispCursor(ch);
+  } while (!ch);
   return(ch);
 }
 

--- a/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
+++ b/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
@@ -493,16 +493,21 @@ extern bool canShowCursor;    // カーソル表示可能か？
 extern void dispCursor(bool forceupdate);
 extern void printString(const char *str);
 
+static uint8 kbhit_char = 0;
+
 int _kbhit(void) {
 //  return(Serial.available());
-  return(Wire.available());
+  if (!kbhit_char) kbhit_char = Wire.requestFrom(CARDKB_ADDR, 1) ? Wire.read() : 0;
+  return kbhit_char;
 }
 
 uint8 _getch(void) {
 //	while (!Serial.available());
 //  return(Serial.read());
   bool needCursorUpdate = false;
-  uint8 ch = Wire.requestFrom(CARDKB_ADDR, 1) ? Wire.read() : 0;
+  if (!kbhit_char) _kbhit();
+  uint8 ch = kbhit_char;
+  kbhit_char = 0;
   switch (ch) {
     case 0x07:
 //    tone(SPK_PIN, 4000, 583);


### PR DESCRIPTION
_kbhit関数には「入力バッファにデータがあるか否かを返す動作」が必要かと思いますが、
CardKBとの通信では概念的にこれに合う動作がないため、
_kbhitの時点で１文字取得させてしまい、文字が得られるかどうかを返すように変更してみました。
また、取得した文字は記憶しておき、_getchにて再利用するようにしています。

当方あまりCP/Mに詳しくないので動作確認の手順がわかっておりませんが、
Issue #2 の問題が改善する可能性があると思います…。