### PR TITLE
update: _getch関数の処理のうちキーコード変更とカーソル描画を_kbhit関数に移設

### DIFF
--- a/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
+++ b/M5Stack_RunCPM_vt100_CardKB/abstraction_arduino.h
@@ -497,37 +497,38 @@ static uint8 kbhit_char = 0;
 
 int _kbhit(void) {
 //  return(Serial.available());
-  if (!kbhit_char) kbhit_char = Wire.requestFrom(CARDKB_ADDR, 1) ? Wire.read() : 0;
+  if (!kbhit_char)
+  {
+    if (Wire.requestFrom(CARDKB_ADDR, 1))
+    {
+      kbhit_char = Wire.read();
+      switch (kbhit_char)
+      {
+      case 0x07:
+  //    tone(SPK_PIN, 4000, 583);
+        break;
+      case 0xa8:    //Fn-C
+        kbhit_char = 0x03;  //Ctrl-C
+        break;
+      case 0x9f:    //Fn-H
+        kbhit_char = 0x08;  //Ctrl-H
+        break;
+      default:
+        break;
+      }
+    }
+  }
+  if (canShowCursor || kbhit_char)
+     dispCursor(kbhit_char);
   return kbhit_char;
 }
 
 uint8 _getch(void) {
 //	while (!Serial.available());
 //  return(Serial.read());
-  uint8 ch = 0;
-  do
-  {
-    if (_kbhit())
-    {
-      ch = kbhit_char;
-      kbhit_char = 0;
-      switch (ch) {
-        case 0x07:
-    //    tone(SPK_PIN, 4000, 583);
-          break;
-        case 0xa8:    //Fn-C
-          ch = 0x03;  //Ctrl-C
-          break;
-        case 0x9f:    //Fn-H
-          ch = 0x08;  //Ctrl-H
-          break;
-        default:
-          break;
-      }
-    }
-    if (canShowCursor || ch)
-       dispCursor(ch);
-  } while (!ch);
+  while (!_kbhit());
+  uint8 ch = kbhit_char;
+  kbhit_char = 0;
   return(ch);
 }
 


### PR DESCRIPTION
_getch関数で処理していたキーコード変更処理とカーソル描画処理を_kbhit関数に移設しました。
これにより_getchを使わない処理ループにおいてもカーソル点滅が行われるようになります。